### PR TITLE
Add Advenir Eligibility Wizard plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+vendor/
+.DS_Store
+*.zip
+*.log

--- a/advenir-eligibility-wizard.php
+++ b/advenir-eligibility-wizard.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name:       Advenir Eligibility Wizard
+ * Plugin URI:        https://example.com/
+ * Description:       Fournit un assistant Advenir pour estimer l'éligibilité et les montants d'aide.
+ * Version:           1.0.0
+ * Author:            Calcul Advenir
+ * License:           GPL-2.0+
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       advenir-eligibility-wizard
+ * Domain Path:       /languages
+ *
+ * @package AdvenirEligibilityWizard
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'AEW_VERSION', '1.0.0' );
+define( 'AEW_PLUGIN_FILE', __FILE__ );
+define( 'AEW_PLUGIN_DIR', plugin_dir_path( AEW_PLUGIN_FILE ) );
+define( 'AEW_PLUGIN_URL', plugin_dir_url( AEW_PLUGIN_FILE ) );
+
+require_once AEW_PLUGIN_DIR . 'includes/class-aew-admin.php';
+require_once AEW_PLUGIN_DIR . 'includes/class-aew-rest.php';
+require_once AEW_PLUGIN_DIR . 'includes/class-aew-frontend.php';
+
+/**
+ * Load the plugin text domain for translation.
+ *
+ * @return void
+ */
+function aew_load_textdomain() {
+	load_plugin_textdomain( 'advenir-eligibility-wizard', false, dirname( plugin_basename( AEW_PLUGIN_FILE ) ) . '/languages' );
+}
+add_action( 'init', 'aew_load_textdomain' );
+
+/**
+ * Bootstrap plugin services.
+ *
+ * @return void
+ */
+function aew_bootstrap() {
+	$admin    = AEW_Admin::get_instance();
+	$rest_api = AEW_REST::get_instance();
+	$frontend = AEW_Frontend::get_instance();
+
+	// The variables are not used further but instantiation is required.
+	if ( ! $admin || ! $rest_api || ! $frontend ) {
+		return;
+	}
+}
+add_action( 'plugins_loaded', 'aew_bootstrap' );

--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -1,0 +1,277 @@
+.aew-container {
+max-width: 640px;
+margin: 0 auto;
+font-family: inherit;
+color: #1f2937;
+}
+
+.aew-card {
+background: #ffffff;
+border-radius: 12px;
+box-shadow: 0 6px 24px rgba(15, 23, 42, 0.08);
+padding: 2rem;
+border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.aew-progress {
+font-weight: 600;
+margin-bottom: 1rem;
+color: #0f172a;
+}
+
+.aew-question-title {
+font-size: 1.5rem;
+margin: 0 0 1rem;
+color: #0f172a;
+}
+
+.aew-question-description {
+margin: 0 0 1.5rem;
+color: #475569;
+}
+
+.aew-options {
+border: 0;
+padding: 0;
+margin: 0;
+}
+
+.aew-option {
+display: flex;
+align-items: center;
+gap: 0.75rem;
+padding: 0.75rem 1rem;
+margin-bottom: 0.5rem;
+border: 1px solid rgba(15, 23, 42, 0.12);
+border-radius: 10px;
+transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.aew-option input[type="radio"] {
+margin: 0;
+}
+
+.aew-option label {
+flex: 1;
+cursor: pointer;
+}
+
+.aew-option:hover,
+.aew-option:focus-within {
+border-color: #2563eb;
+box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.aew-number-field input[type="number"] {
+width: 100%;
+padding: 0.75rem 1rem;
+border-radius: 10px;
+border: 1px solid rgba(15, 23, 42, 0.12);
+font-size: 1rem;
+}
+
+.aew-number-field input[type="number"]:focus {
+outline: none;
+border-color: #2563eb;
+box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.aew-field-error {
+margin-top: 0.75rem;
+color: #dc2626;
+font-weight: 600;
+}
+
+.aew-navigation {
+display: flex;
+justify-content: space-between;
+align-items: center;
+margin-top: 2rem;
+gap: 1rem;
+}
+
+.aew-btn {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+gap: 0.5rem;
+padding: 0.75rem 1.5rem;
+border-radius: 9999px;
+font-weight: 600;
+cursor: pointer;
+border: none;
+transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.aew-btn-primary {
+background: linear-gradient(135deg, #2563eb, #1d4ed8);
+color: #ffffff;
+box-shadow: 0 12px 30px rgba(37, 99, 235, 0.25);
+}
+
+.aew-btn-primary:hover,
+.aew-btn-primary:focus-visible {
+transform: translateY(-1px);
+box-shadow: 0 16px 40px rgba(37, 99, 235, 0.35);
+}
+
+.aew-btn-secondary {
+background: #e2e8f0;
+color: #1f2937;
+}
+
+.aew-btn-secondary:hover,
+.aew-btn-secondary:focus-visible {
+background: #cbd5f5;
+}
+
+.aew-btn:disabled {
+opacity: 0.5;
+cursor: not-allowed;
+box-shadow: none;
+}
+
+.aew-result {
+margin-top: 2rem;
+}
+
+.aew-result-card {
+border-radius: 12px;
+border: 1px solid rgba(15, 23, 42, 0.12);
+padding: 1.75rem;
+background: #f8fafc;
+}
+
+.aew-result-title {
+margin: 0 0 1rem;
+font-size: 1.4rem;
+}
+
+.aew-result-title--success {
+color: #047857;
+}
+
+.aew-result-title--warning {
+color: #b91c1c;
+}
+
+.aew-result-message {
+margin: 0 0 1.5rem;
+color: #334155;
+}
+
+.aew-amounts {
+display: grid;
+grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+gap: 1rem;
+margin: 0 0 1.5rem;
+}
+
+.aew-amounts dt {
+font-weight: 600;
+color: #0f172a;
+}
+
+.aew-amounts dd {
+margin: 0;
+color: #1e293b;
+font-size: 1.1rem;
+}
+
+.aew-scenario {
+background: #ffffff;
+border-radius: 10px;
+padding: 1rem 1.25rem;
+border: 1px solid rgba(37, 99, 235, 0.2);
+margin-bottom: 1.5rem;
+}
+
+.aew-scenario-title {
+margin: 0 0 0.5rem;
+font-weight: 600;
+color: #1d4ed8;
+}
+
+.aew-footnote {
+margin: 0.5rem 0 0;
+font-size: 0.875rem;
+color: #475569;
+}
+
+.aew-summary-title {
+margin: 0 0 0.75rem;
+font-size: 1.1rem;
+font-weight: 600;
+}
+
+.aew-summary {
+list-style: none;
+padding: 0;
+margin: 0;
+display: grid;
+gap: 0.75rem;
+}
+
+.aew-summary li {
+display: flex;
+justify-content: space-between;
+gap: 1rem;
+background: #ffffff;
+border-radius: 10px;
+padding: 0.75rem 1rem;
+border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.aew-summary-label {
+font-weight: 600;
+color: #1f2937;
+}
+
+.aew-summary-value {
+color: #0f172a;
+}
+
+.aew-loading {
+text-align: center;
+color: #1f2937;
+}
+
+.aew-error-card {
+background: #fef2f2;
+border: 1px solid #fca5a5;
+border-radius: 10px;
+padding: 1.5rem;
+text-align: center;
+}
+
+.aew-error-title {
+margin-top: 0;
+color: #b91c1c;
+}
+
+.aew-visually-hidden {
+position: absolute;
+width: 1px;
+height: 1px;
+padding: 0;
+margin: -1px;
+overflow: hidden;
+clip: rect(0, 0, 0, 0);
+white-space: nowrap;
+border: 0;
+}
+
+@media (max-width: 600px) {
+.aew-card {
+padding: 1.5rem;
+}
+
+.aew-navigation {
+flex-direction: column;
+align-items: stretch;
+}
+
+.aew-btn {
+width: 100%;
+}
+}

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -1,0 +1,517 @@
+(function () {
+'use strict';
+
+if ( typeof window.aewData === 'undefined' ) {
+return;
+}
+
+const data = window.aewData;
+const restUrl = data.restUrl || '';
+const nonce = data.nonce || '';
+const i18n = data.i18n || {};
+const baseUrl = restUrl.endsWith( '/' ) ? restUrl : restUrl + '/';
+
+class AdvenirWizard {
+constructor( container ) {
+this.container = container;
+this.progressEl = container.querySelector( '.aew-progress' );
+this.stepEl = container.querySelector( '[data-aew-step-container]' );
+this.prevButton = container.querySelector( '[data-aew-prev]' );
+this.nextButton = container.querySelector( '[data-aew-next]' );
+this.resultEl = container.querySelector( '[data-aew-result]' );
+
+this.questions = [];
+this.meta = {};
+this.resultMessages = {};
+this.currentIndex = 0;
+this.answers = {};
+
+this.handlePrev = this.handlePrev.bind( this );
+this.handleNext = this.handleNext.bind( this );
+
+this.prevButton.addEventListener( 'click', this.handlePrev );
+this.nextButton.addEventListener( 'click', this.handleNext );
+}
+
+async init() {
+this.setLoadingState( true );
+
+try {
+const response = await fetch( baseUrl + 'config', { credentials: 'same-origin' } );
+
+if ( ! response.ok ) {
+throw new Error( 'config_error' );
+}
+
+const data = await response.json();
+this.questions = Array.isArray( data.questions ) ? data.questions : [];
+this.meta = data.meta || {};
+this.resultMessages = data.results || {};
+
+if ( this.questions.length === 0 ) {
+this.showErrorState( i18n.empty || 'Aucune question disponible.' );
+return;
+}
+
+this.currentIndex = 0;
+this.renderStep();
+this.updateProgress();
+this.setLoadingState( false );
+} catch ( error ) {
+this.showErrorState( i18n.loadError || 'Impossible de charger le questionnaire.' );
+}
+}
+
+setLoadingState( isLoading ) {
+if ( isLoading ) {
+this.stepEl.innerHTML = '';
+const loading = document.createElement( 'p' );
+loading.className = 'aew-loading';
+loading.textContent = i18n.loading || 'Chargement…';
+this.stepEl.appendChild( loading );
+this.prevButton.disabled = true;
+this.nextButton.disabled = true;
+} else {
+this.prevButton.disabled = this.currentIndex === 0;
+this.nextButton.disabled = false;
+}
+}
+
+showErrorState( message ) {
+this.stepEl.innerHTML = '';
+const wrapper = document.createElement( 'div' );
+wrapper.className = 'aew-error-card';
+
+const title = document.createElement( 'h3' );
+title.className = 'aew-error-title';
+title.textContent = i18n.errorTitle || 'Une erreur est survenue';
+
+const text = document.createElement( 'p' );
+text.textContent = message;
+
+const retry = document.createElement( 'button' );
+retry.type = 'button';
+retry.className = 'aew-btn aew-btn-primary';
+retry.textContent = i18n.retry || 'Réessayer';
+retry.addEventListener( 'click', () => this.init() );
+
+wrapper.appendChild( title );
+wrapper.appendChild( text );
+wrapper.appendChild( retry );
+this.stepEl.appendChild( wrapper );
+this.prevButton.disabled = true;
+this.nextButton.disabled = true;
+}
+
+renderStep() {
+this.stepEl.innerHTML = '';
+this.resultEl.hidden = true;
+this.resultEl.innerHTML = '';
+
+const question = this.questions[ this.currentIndex ];
+if ( ! question ) {
+return;
+}
+
+const container = document.createElement( 'div' );
+container.className = 'aew-question';
+
+const title = document.createElement( 'h2' );
+title.className = 'aew-question-title';
+title.textContent = question.label || '';
+container.appendChild( title );
+
+if ( question.description ) {
+const description = document.createElement( 'p' );
+description.className = 'aew-question-description';
+description.textContent = String( question.description );
+container.appendChild( description );
+}
+
+const field = question.type === 'number' ? this.renderNumberField( question ) : this.renderSingleChoiceField( question );
+container.appendChild( field );
+
+const error = document.createElement( 'div' );
+error.className = 'aew-field-error';
+error.id = 'aew-error-' + question.id;
+error.setAttribute( 'role', 'alert' );
+error.setAttribute( 'aria-live', 'polite' );
+container.appendChild( error );
+
+this.stepEl.appendChild( container );
+this.updateButtons();
+}
+
+renderSingleChoiceField( question ) {
+const fieldset = document.createElement( 'fieldset' );
+fieldset.className = 'aew-options';
+fieldset.setAttribute( 'data-question', question.id );
+
+const legend = document.createElement( 'legend' );
+legend.className = 'aew-visually-hidden';
+legend.textContent = question.label || '';
+fieldset.appendChild( legend );
+
+const options = Array.isArray( question.options ) ? question.options : [];
+const savedValue = this.answers[ question.id ];
+
+options.forEach( ( option, index ) => {
+const optionId = 'aew-' + question.id + '-' + index;
+
+const wrapper = document.createElement( 'div' );
+wrapper.className = 'aew-option';
+
+const input = document.createElement( 'input' );
+input.type = 'radio';
+input.name = question.id;
+input.id = optionId;
+input.value = option.value;
+input.required = !! question.required;
+
+if ( savedValue && savedValue === option.value ) {
+input.checked = true;
+}
+
+const label = document.createElement( 'label' );
+label.htmlFor = optionId;
+label.textContent = option.label || option.value;
+
+wrapper.appendChild( input );
+wrapper.appendChild( label );
+fieldset.appendChild( wrapper );
+} );
+
+return fieldset;
+}
+
+renderNumberField( question ) {
+const wrapper = document.createElement( 'div' );
+wrapper.className = 'aew-number-field';
+
+const input = document.createElement( 'input' );
+input.type = 'number';
+input.name = question.id;
+input.id = 'aew-' + question.id;
+input.required = !! question.required;
+
+if ( question.attributes ) {
+const attrs = question.attributes;
+if ( typeof attrs.min !== 'undefined' ) {
+input.min = attrs.min;
+}
+if ( typeof attrs.max !== 'undefined' ) {
+input.max = attrs.max;
+}
+if ( typeof attrs.step !== 'undefined' ) {
+input.step = attrs.step;
+}
+if ( typeof attrs.placeholder !== 'undefined' ) {
+input.placeholder = attrs.placeholder;
+}
+}
+
+if ( typeof this.answers[ question.id ] !== 'undefined' ) {
+input.value = this.answers[ question.id ];
+}
+
+const label = document.createElement( 'label' );
+label.className = 'aew-visually-hidden';
+label.htmlFor = input.id;
+label.textContent = question.label || '';
+
+wrapper.appendChild( label );
+wrapper.appendChild( input );
+
+return wrapper;
+}
+
+handlePrev() {
+if ( this.currentIndex === 0 ) {
+return;
+}
+
+this.currentIndex -= 1;
+this.renderStep();
+this.updateProgress();
+}
+
+async handleNext() {
+if ( ! this.validateCurrentStep() ) {
+return;
+}
+
+if ( this.currentIndex === this.questions.length - 1 ) {
+await this.evaluate();
+return;
+}
+
+this.currentIndex += 1;
+this.renderStep();
+this.updateProgress();
+}
+
+validateCurrentStep() {
+const question = this.questions[ this.currentIndex ];
+if ( ! question ) {
+return false;
+}
+
+const error = this.stepEl.querySelector( '.aew-field-error' );
+if ( error ) {
+error.textContent = '';
+}
+
+if ( question.type === 'number' ) {
+const input = this.stepEl.querySelector( 'input[name="' + question.id + '"]' );
+if ( ! input ) {
+return false;
+}
+
+const value = input.value.trim();
+if ( value === '' ) {
+return this.setFieldError( error, i18n.required || 'Cette information est obligatoire.' );
+}
+
+const numberValue = Number( value );
+if ( Number.isNaN( numberValue ) ) {
+return this.setFieldError( error, i18n.invalidNumber || 'Merci d’entrer un nombre valide.' );
+}
+
+if ( input.min !== '' && ! Number.isNaN( Number( input.min ) ) && numberValue < Number( input.min ) ) {
+const msg = i18n.minValue ? i18n.minValue.replace( '%s', input.min ) : 'Valeur trop faible.';
+return this.setFieldError( error, msg );
+}
+
+if ( input.max !== '' && ! Number.isNaN( Number( input.max ) ) && numberValue > Number( input.max ) ) {
+const msg = i18n.maxValue ? i18n.maxValue.replace( '%s', input.max ) : 'Valeur trop élevée.';
+return this.setFieldError( error, msg );
+}
+
+this.answers[ question.id ] = numberValue;
+return true;
+}
+
+const checked = this.stepEl.querySelector( 'input[name="' + question.id + '"]:checked' );
+if ( ! checked ) {
+return this.setFieldError( error, i18n.required || 'Cette information est obligatoire.' );
+}
+
+this.answers[ question.id ] = checked.value;
+return true;
+}
+
+setFieldError( errorEl, message ) {
+if ( errorEl ) {
+errorEl.textContent = message;
+}
+
+return false;
+}
+
+updateProgress() {
+if ( ! this.progressEl ) {
+return;
+}
+
+const stepLabel = i18n.step || 'Étape';
+const ofLabel = i18n.of || 'sur';
+this.progressEl.textContent = stepLabel + ' ' + ( this.currentIndex + 1 ) + ' ' + ofLabel + ' ' + this.questions.length;
+}
+
+updateButtons() {
+this.prevButton.disabled = this.currentIndex === 0;
+this.nextButton.textContent = this.currentIndex === this.questions.length - 1 ? ( i18n.submit || 'Calculer mon éligibilité' ) : ( i18n.next || 'Suivant' );
+}
+
+async evaluate() {
+this.nextButton.disabled = true;
+this.prevButton.disabled = true;
+this.resultEl.hidden = false;
+this.resultEl.innerHTML = '';
+
+const loader = document.createElement( 'p' );
+loader.className = 'aew-loading';
+loader.textContent = i18n.loading || 'Chargement…';
+this.resultEl.appendChild( loader );
+
+try {
+const response = await fetch( baseUrl + 'evaluate', {
+method: 'POST',
+credentials: 'same-origin',
+headers: {
+'Content-Type': 'application/json',
+'X-WP-Nonce': nonce,
+},
+body: JSON.stringify( { answers: this.answers } ),
+} );
+
+const payload = await response.json();
+
+if ( ! response.ok ) {
+throw new Error( payload.message || 'evaluate_error' );
+}
+
+this.renderResult( payload );
+} catch ( error ) {
+this.resultEl.innerHTML = '';
+const errorBlock = document.createElement( 'div' );
+errorBlock.className = 'aew-error-card';
+
+const title = document.createElement( 'h3' );
+title.className = 'aew-error-title';
+title.textContent = i18n.errorTitle || 'Une erreur est survenue';
+
+const text = document.createElement( 'p' );
+text.textContent = typeof error.message === 'string' ? error.message : ( i18n.loadError || 'Une erreur est survenue.' );
+
+errorBlock.appendChild( title );
+errorBlock.appendChild( text );
+this.resultEl.appendChild( errorBlock );
+} finally {
+this.nextButton.disabled = false;
+this.prevButton.disabled = false;
+}
+}
+
+renderResult( payload ) {
+this.resultEl.innerHTML = '';
+
+const wrapper = document.createElement( 'div' );
+wrapper.className = 'aew-result-card';
+
+const heading = document.createElement( 'h3' );
+const headingClass = payload.eligible ? 'aew-result-title aew-result-title--success' : 'aew-result-title aew-result-title--warning';
+const fallbackTitle = payload.eligible ? ( i18n.successTitle || 'Félicitations !' ) : ( i18n.infoTitle || 'Information' );
+heading.textContent = ( payload.messages && payload.messages.title ) || fallbackTitle;
+heading.className = headingClass;
+wrapper.appendChild( heading );
+
+if ( payload.messages && payload.messages.message ) {
+const lead = document.createElement( 'p' );
+lead.className = 'aew-result-message';
+lead.textContent = payload.messages.message;
+wrapper.appendChild( lead );
+}
+
+if ( payload.eligible && payload.amounts ) {
+const amountsList = document.createElement( 'dl' );
+amountsList.className = 'aew-amounts';
+
+const currency = payload.amounts.currency || this.meta.currency || 'EUR';
+const perPoint = this.formatCurrency( payload.amounts.amount_per_point || 0, currency );
+const total = this.formatCurrency( payload.amounts.total || 0, currency );
+
+amountsList.appendChild( this.createDefinition( i18n.perPoint || 'Montant par point', perPoint ) );
+amountsList.appendChild( this.createDefinition( i18n.pointsEligible || 'Points éligibles', String( payload.amounts.points_eligible || 0 ) ) );
+if ( typeof payload.amounts.points_requested !== 'undefined' ) {
+amountsList.appendChild( this.createDefinition( i18n.pointsRequested || 'Points demandés', String( payload.amounts.points_requested ) ) );
+}
+amountsList.appendChild( this.createDefinition( i18n.totalEstimated || 'Total estimé', total ) );
+
+wrapper.appendChild( amountsList );
+
+if ( payload.scenario ) {
+const scenarioBlock = document.createElement( 'div' );
+scenarioBlock.className = 'aew-scenario';
+
+if ( payload.scenario.label ) {
+const scenarioTitle = document.createElement( 'p' );
+scenarioTitle.className = 'aew-scenario-title';
+scenarioTitle.textContent = payload.scenario.label;
+scenarioBlock.appendChild( scenarioTitle );
+}
+
+if ( payload.scenario.success_message ) {
+const scenarioMessage = document.createElement( 'p' );
+scenarioMessage.textContent = payload.scenario.success_message;
+scenarioBlock.appendChild( scenarioMessage );
+}
+
+if ( payload.scenario.footnote ) {
+const footnote = document.createElement( 'p' );
+footnote.className = 'aew-footnote';
+footnote.textContent = payload.scenario.footnote;
+scenarioBlock.appendChild( footnote );
+}
+
+wrapper.appendChild( scenarioBlock );
+}
+}
+
+const summaryTitle = document.createElement( 'h4' );
+summaryTitle.className = 'aew-summary-title';
+summaryTitle.textContent = i18n.answersTitle || 'Vos réponses';
+wrapper.appendChild( summaryTitle );
+
+const list = document.createElement( 'ul' );
+list.className = 'aew-summary';
+
+this.questions.forEach( ( question ) => {
+const answer = this.answers[ question.id ];
+if ( typeof answer === 'undefined' ) {
+return;
+}
+
+const item = document.createElement( 'li' );
+const label = document.createElement( 'span' );
+label.className = 'aew-summary-label';
+label.textContent = question.label || question.id;
+
+const valueSpan = document.createElement( 'span' );
+valueSpan.className = 'aew-summary-value';
+
+if ( question.type === 'number' ) {
+valueSpan.textContent = String( answer );
+} else {
+const optionLabel = this.findOptionLabel( question, answer );
+valueSpan.textContent = optionLabel || answer;
+}
+
+item.appendChild( label );
+item.appendChild( valueSpan );
+list.appendChild( item );
+} );
+
+wrapper.appendChild( list );
+this.resultEl.appendChild( wrapper );
+}
+
+createDefinition( label, value ) {
+const fragment = document.createDocumentFragment();
+const term = document.createElement( 'dt' );
+term.textContent = label;
+const definition = document.createElement( 'dd' );
+definition.textContent = value;
+fragment.appendChild( term );
+fragment.appendChild( definition );
+return fragment;
+}
+
+findOptionLabel( question, value ) {
+const options = Array.isArray( question.options ) ? question.options : [];
+const match = options.find( ( option ) => option.value === value );
+return match ? match.label : '';
+}
+
+formatCurrency( amount, currency ) {
+try {
+return new Intl.NumberFormat( 'fr-FR', {
+style: 'currency',
+currency: currency || 'EUR',
+maximumFractionDigits: 0,
+} ).format( amount );
+} catch ( error ) {
+return amount + ' ' + ( currency || 'EUR' );
+}
+}
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+const containers = document.querySelectorAll( '[data-aew-wizard]' );
+
+containers.forEach( ( container ) => {
+const wizard = new AdvenirWizard( container );
+wizard.init();
+} );
+} );
+})();

--- a/includes/class-aew-admin.php
+++ b/includes/class-aew-admin.php
@@ -1,0 +1,310 @@
+
+<?php
+/**
+ * Admin functionality for Advenir Eligibility Wizard.
+ *
+ * @package AdvenirEligibilityWizard
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AEW_Admin
+ */
+class AEW_Admin {
+
+	/**
+	 * Option key used to persist rules JSON.
+	 *
+	 * @var string
+	 */
+	const OPTION_KEY = 'aew_rules_json';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var AEW_Admin|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Retrieve singleton instance.
+	 *
+	 * @return AEW_Admin
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * AEW_Admin constructor.
+	 */
+	private function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+	}
+
+	/**
+	 * Register the plugin admin menu.
+	 *
+	 * @return void
+	 */
+	public function register_menu() {
+		add_menu_page(
+			esc_html__( 'Assistant Advenir', 'advenir-eligibility-wizard' ),
+			esc_html__( 'Advenir Wizard', 'advenir-eligibility-wizard' ),
+			'manage_options',
+			'aew-settings',
+			array( $this, 'render_page' ),
+			'dashicons-admin-generic',
+			59
+		);
+	}
+
+	/**
+	 * Register the settings required for the JSON ruleset.
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			'aew_settings',
+			self::OPTION_KEY,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_rules' ),
+				'show_in_rest'      => false,
+			)
+		);
+	}
+
+	/**
+	 * Sanitize and validate JSON configuration before saving.
+	 *
+	 * @param string $value Raw textarea value.
+	 *
+	 * @return string
+	 */
+	public function sanitize_rules( $value ) {
+		$current_value = get_option( self::OPTION_KEY, self::get_default_rules_json() );
+		$value         = is_string( $value ) ? wp_unslash( $value ) : '';
+
+		if ( '' === trim( $value ) ) {
+			add_settings_error( self::OPTION_KEY, 'aew_rules_empty', esc_html__( 'Le JSON ne peut pas être vide.', 'advenir-eligibility-wizard' ) );
+
+			return $current_value;
+		}
+
+		$decoded = json_decode( $value, true );
+
+		if ( null === $decoded || ! is_array( $decoded ) ) {
+			add_settings_error( self::OPTION_KEY, 'aew_rules_invalid', esc_html__( 'Le JSON fourni est invalide. Merci de vérifier la syntaxe.', 'advenir-eligibility-wizard' ) );
+
+			return $current_value;
+		}
+
+		return wp_json_encode( $decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+	}
+
+	/**
+	 * Render the admin configuration page.
+	 *
+	 * @return void
+	 */
+	public function render_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$rules_json = get_option( self::OPTION_KEY, self::get_default_rules_json() );
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html__( 'Assistant Advenir – Règles', 'advenir-eligibility-wizard' ); ?></h1>
+			<form action="options.php" method="post">
+				<?php settings_fields( 'aew_settings' ); ?>
+				<?php do_settings_sections( 'aew_settings' ); ?>
+				<?php settings_errors( self::OPTION_KEY ); ?>
+				<p class="description">
+				<?php echo esc_html__( 'Collez ou modifiez le JSON décrivant les questions, scénarios et textes du parcours. Vérifiez régulièrement les barèmes officiels Advenir.', 'advenir-eligibility-wizard' ); ?>
+				</p>
+				<textarea name="<?php echo esc_attr( self::OPTION_KEY ); ?>" rows="25" class="large-text code"><?php echo esc_textarea( $rules_json ); ?></textarea>
+				<?php submit_button( esc_html__( 'Enregistrer les règles', 'advenir-eligibility-wizard' ) ); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Retrieve the decoded rules configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_rules() {
+		$json = get_option( self::OPTION_KEY, self::get_default_rules_json() );
+		$data = json_decode( $json, true );
+
+		if ( null === $data || ! is_array( $data ) ) {
+			$data = self::get_default_rules_array();
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Return the default configuration as a JSON string.
+	 *
+	 * @return string
+	 */
+	public static function get_default_rules_json() {
+		return wp_json_encode( self::get_default_rules_array(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+	}
+
+	/**
+	 * Default configuration array.
+	 *
+	 * @return array
+	 */
+	public static function get_default_rules_array() {
+		return array(
+			'_meta'     => array(
+				'last_updated' => '2025-09-26T00:00:00Z',
+				'currency'     => 'EUR',
+				'notes'        => 'Exemples. Mettez à jour selon les barèmes Advenir en vigueur.',
+			),
+			'questions' => array(
+				array(
+					'id'       => 'beneficiary',
+					'label'    => 'Qui êtes-vous ?',
+					'type'     => 'single',
+					'required' => true,
+					'options'  => array(
+						array(
+							'value' => 'particulier',
+							'label' => 'Particulier (maison individuelle)',
+						),
+						array(
+							'value' => 'copro',
+							'label' => 'Copropriété (parking collectif)',
+						),
+						array(
+							'value' => 'entreprise_prive',
+							'label' => 'Entreprise — Parking privé réservé aux salariés',
+						),
+						array(
+							'value' => 'entreprise_public',
+							'label' => 'Entreprise — Parking ouvert au public',
+						),
+						array(
+							'value' => 'collectivite',
+							'label' => 'Collectivité / acteur public',
+						),
+					),
+				),
+				array(
+					'id'       => 'site',
+					'label'    => 'Où se situe l’installation ?',
+					'type'     => 'single',
+					'required' => true,
+					'options'  => array(
+						array(
+							'value' => 'residence_principale',
+							'label' => 'Résidence principale',
+						),
+						array(
+							'value' => 'residence_secondaire',
+							'label' => 'Résidence secondaire',
+						),
+						array(
+							'value' => 'site_entreprise',
+							'label' => 'Site d’entreprise / local professionnel',
+						),
+					),
+				),
+				array(
+					'id'       => 'usage',
+					'label'    => 'Quel sera l’usage principal de la borne ?',
+					'type'     => 'single',
+					'required' => true,
+					'options'  => array(
+						array(
+							'value' => 'usage_prive',
+							'label' => 'Usage privé (accès réservé)',
+						),
+						array(
+							'value' => 'usage_residentiel_partage',
+							'label' => 'Usage résidentiel partagé',
+						),
+						array(
+							'value' => 'usage_public',
+							'label' => 'Usage ouvert au public',
+						),
+					),
+				),
+				array(
+					'id'         => 'points',
+					'label'      => 'Combien de points de charge souhaitez-vous installer ?',
+					'type'       => 'number',
+					'required'   => true,
+					'attributes' => array(
+						'placeholder' => 1,
+						'min'         => 1,
+						'max'         => 50,
+						'step'        => 1,
+					),
+				),
+			),
+			'scenarios' => array(
+				array(
+					'id'               => 'scenario_particulier',
+					'label'            => 'Particulier résidentiel',
+					'conditions'       => array(
+						'beneficiary' => array( 'particulier' ),
+						'usage'       => array( 'usage_prive' ),
+					),
+					'max_points'       => 1,
+					'amount_per_point' => 960,
+					'footnote'         => 'Montant indicatif pour un point de charge résidentiel individuel (≤22 kW).',
+					'success_message'  => 'Votre profil correspond aux installations individuelles financées par Advenir.',
+				),
+				array(
+					'id'               => 'scenario_copro',
+					'label'            => 'Copropriété / résidentiel collectif',
+					'conditions'       => array(
+						'beneficiary' => array( 'copro' ),
+						'usage'       => array( 'usage_residentiel_partage' ),
+					),
+					'max_points'       => 20,
+					'amount_per_point' => 1500,
+					'footnote'         => 'Montant indicatif pour les copropriétés. Vérifiez le plafond annuel en vigueur.',
+					'success_message'  => 'Votre copropriété peut bénéficier d’un accompagnement renforcé du programme.',
+				),
+				array(
+					'id'               => 'scenario_public',
+					'label'            => 'Ouverture au public (entreprise ou collectivité)',
+					'conditions'       => array(
+						'beneficiary' => array( 'entreprise_public', 'collectivite' ),
+						'usage'       => array( 'usage_public' ),
+					),
+					'max_points'       => 40,
+					'amount_per_point' => 2400,
+					'footnote'         => 'Montant indicatif pour les points ouverts au public, soumis aux plafonds Advenir.',
+					'success_message'  => 'Votre projet contribue au maillage public et peut prétendre aux aides dédiées.',
+				),
+			),
+			'results'   => array(
+				'eligible'    => array(
+					'title'   => 'Félicitations !',
+					'message' => 'Selon vos réponses, votre projet semble répondre aux critères du programme Advenir. Déposez un dossier officiel pour confirmation.',
+				),
+				'not_eligible' => array(
+					'title'   => 'Pas d’éligibilité apparente',
+					'message' => 'Selon vos réponses, le projet ne semble pas entrer dans le périmètre actuel du programme. Vérifiez les critères ou contactez le service Advenir.',
+				),
+			),
+		);
+	}
+}

--- a/includes/class-aew-frontend.php
+++ b/includes/class-aew-frontend.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Front-end integration for Advenir Eligibility Wizard.
+ *
+ * @package AdvenirEligibilityWizard
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AEW_Frontend
+ */
+class AEW_Frontend {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var AEW_Frontend|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Retrieve singleton instance.
+	 *
+	 * @return AEW_Frontend
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Track whether assets were enqueued.
+	 *
+	 * @var bool
+	 */
+	private $assets_enqueued = false;
+
+	/**
+	 * AEW_Frontend constructor.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_shortcode' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
+	}
+
+	/**
+	 * Register the shortcode handler.
+	 *
+	 * @return void
+	 */
+	public function register_shortcode() {
+		add_shortcode( 'advenir_wizard', array( $this, 'render_shortcode' ) );
+	}
+
+	/**
+	 * Register front-end assets.
+	 *
+	 * @return void
+	 */
+	public function register_assets() {
+		wp_register_style(
+			'advenir-eligibility-wizard',
+			AEW_PLUGIN_URL . 'assets/css/wizard.css',
+			array(),
+			AEW_VERSION
+		);
+
+		wp_register_script(
+			'advenir-eligibility-wizard',
+			AEW_PLUGIN_URL . 'assets/js/wizard.js',
+			array(),
+			AEW_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Render the shortcode output.
+	 *
+	 * @return string
+	 */
+	public function render_shortcode() {
+		if ( ! $this->assets_enqueued ) {
+			wp_enqueue_style( 'advenir-eligibility-wizard' );
+			wp_enqueue_script( 'advenir-eligibility-wizard' );
+			wp_localize_script(
+				'advenir-eligibility-wizard',
+				'aewData',
+				array(
+					'restUrl' => esc_url_raw( rest_url( AEW_REST::REST_NAMESPACE . '/' ) ),
+					'nonce'   => wp_create_nonce( 'wp_rest' ),
+					'i18n'    => array(
+						'next'            => esc_html__( 'Suivant', 'advenir-eligibility-wizard' ),
+						'previous'        => esc_html__( 'Précédent', 'advenir-eligibility-wizard' ),
+						'submit'          => esc_html__( 'Calculer mon éligibilité', 'advenir-eligibility-wizard' ),
+						'step'            => esc_html__( 'Étape', 'advenir-eligibility-wizard' ),
+						'of'              => esc_html__( 'sur', 'advenir-eligibility-wizard' ),
+						'loading'         => esc_html__( 'Chargement…', 'advenir-eligibility-wizard' ),
+						'errorTitle'      => esc_html__( 'Une erreur est survenue', 'advenir-eligibility-wizard' ),
+						'retry'           => esc_html__( 'Réessayer', 'advenir-eligibility-wizard' ),
+						'empty'           => esc_html__( 'Aucune question disponible.', 'advenir-eligibility-wizard' ),
+						'loadError'       => esc_html__( 'Impossible de charger le questionnaire.', 'advenir-eligibility-wizard' ),
+						'required'        => esc_html__( 'Cette information est obligatoire.', 'advenir-eligibility-wizard' ),
+						'invalidNumber'   => esc_html__( 'Merci d’entrer un nombre valide.', 'advenir-eligibility-wizard' ),
+						'minValue'        => esc_html__( 'Valeur trop faible (minimum %s).', 'advenir-eligibility-wizard' ),
+						'maxValue'        => esc_html__( 'Valeur trop élevée (maximum %s).', 'advenir-eligibility-wizard' ),
+						'perPoint'        => esc_html__( 'Montant par point', 'advenir-eligibility-wizard' ),
+						'pointsEligible'  => esc_html__( 'Points éligibles', 'advenir-eligibility-wizard' ),
+						'pointsRequested' => esc_html__( 'Points demandés', 'advenir-eligibility-wizard' ),
+						'totalEstimated'  => esc_html__( 'Total estimé', 'advenir-eligibility-wizard' ),
+						'answersTitle'    => esc_html__( 'Vos réponses', 'advenir-eligibility-wizard' ),
+						'successTitle'    => esc_html__( 'Félicitations !', 'advenir-eligibility-wizard' ),
+						'infoTitle'       => esc_html__( 'Information', 'advenir-eligibility-wizard' ),
+					),
+				)
+			);
+			$this->assets_enqueued = true;
+		}
+
+		ob_start();
+		?>
+		<div class="aew-container" data-aew-wizard>
+			<div class="aew-card">
+				<div class="aew-progress" aria-live="polite"></div>
+				<div class="aew-step" data-aew-step-container></div>
+				<div class="aew-navigation">
+					<button type="button" class="aew-btn aew-btn-secondary" data-aew-prev disabled>
+						<?php echo esc_html__( 'Précédent', 'advenir-eligibility-wizard' ); ?>
+					</button>
+					<button type="button" class="aew-btn aew-btn-primary" data-aew-next>
+						<?php echo esc_html__( 'Suivant', 'advenir-eligibility-wizard' ); ?>
+					</button>
+				</div>
+				<div class="aew-result" aria-live="polite" data-aew-result hidden></div>
+			</div>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/includes/class-aew-rest.php
+++ b/includes/class-aew-rest.php
@@ -1,0 +1,328 @@
+
+<?php
+/**
+ * REST API layer for Advenir Eligibility Wizard.
+ *
+ * @package AdvenirEligibilityWizard
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AEW_REST
+ */
+class AEW_REST {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var AEW_REST|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'aew/v1';
+
+	/**
+	 * Retrieve singleton instance.
+	 *
+	 * @return AEW_REST
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * AEW_REST constructor.
+	 */
+	private function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/config',
+			array(
+				'args'                => array(),
+				'callback'            => array( $this, 'get_config' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/evaluate',
+			array(
+				'args'                => array(),
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'evaluate_answers' ),
+				'permission_callback' => array( $this, 'validate_nonce' ),
+			)
+		);
+	}
+
+	/**
+	 * Return the active configuration for the wizard.
+	 *
+	 * @param WP_REST_Request $request Request instance.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_config( WP_REST_Request $request ) {
+		$rules = AEW_Admin::get_rules();
+
+		$response = array(
+			'questions' => isset( $rules['questions'] ) ? array_values( $rules['questions'] ) : array(),
+			'results'   => isset( $rules['results'] ) ? $rules['results'] : array(),
+			'meta'      => array(
+				'last_updated' => isset( $rules['_meta']['last_updated'] ) ? $rules['_meta']['last_updated'] : '',
+				'currency'     => isset( $rules['_meta']['currency'] ) ? $rules['_meta']['currency'] : 'EUR',
+				'notes'        => isset( $rules['_meta']['notes'] ) ? $rules['_meta']['notes'] : '',
+			),
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Evaluate answers against stored scenarios.
+	 *
+	 * @param WP_REST_Request $request Request instance.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function evaluate_answers( WP_REST_Request $request ) {
+		$rules   = AEW_Admin::get_rules();
+		$answers = $request->get_param( 'answers' );
+
+		if ( empty( $answers ) || ! is_array( $answers ) ) {
+			return new WP_Error( 'aew_missing_answers', esc_html__( 'Aucune réponse valide n’a été fournie.', 'advenir-eligibility-wizard' ), array( 'status' => 400 ) );
+		}
+
+		$questions     = isset( $rules['questions'] ) ? $rules['questions'] : array();
+		$sanitized     = array();
+		$missing       = array();
+		$invalid_types = array();
+
+		foreach ( $questions as $question ) {
+			if ( empty( $question['id'] ) ) {
+				continue;
+			}
+
+			$question_id = sanitize_key( $question['id'] );
+			$is_required = ! empty( $question['required'] );
+
+			if ( ! array_key_exists( $question_id, $answers ) ) {
+				if ( $is_required ) {
+					$missing[] = $question_id;
+				}
+
+				continue;
+			}
+
+			$raw_value = $answers[ $question_id ];
+			$type      = isset( $question['type'] ) ? $question['type'] : 'single';
+
+			switch ( $type ) {
+				case 'number':
+					if ( ! is_numeric( $raw_value ) ) {
+						$invalid_types[] = $question_id;
+						break;
+					}
+
+					$sanitized[ $question_id ] = (int) $raw_value;
+					break;
+				case 'single':
+				default:
+					$sanitized[ $question_id ] = sanitize_text_field( wp_unslash( $raw_value ) );
+					break;
+			}
+		}
+
+		if ( ! empty( $missing ) ) {
+			return new WP_Error(
+				'aew_missing_fields',
+				sprintf(
+					/* translators: %s: comma-separated list of missing fields */
+					esc_html__( 'Merci de répondre à toutes les questions obligatoires (%s).', 'advenir-eligibility-wizard' ),
+					implode( ', ', $missing )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! empty( $invalid_types ) ) {
+			return new WP_Error(
+				'aew_invalid_answers',
+				sprintf(
+					/* translators: %s: comma-separated list of invalid fields */
+					esc_html__( 'Certaines réponses ne sont pas du bon format (%s).', 'advenir-eligibility-wizard' ),
+					implode( ', ', $invalid_types )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		$matched = $this->match_scenario( isset( $rules['scenarios'] ) ? $rules['scenarios'] : array(), $sanitized );
+
+		if ( empty( $matched ) ) {
+			$results = isset( $rules['results']['not_eligible'] ) ? $rules['results']['not_eligible'] : array();
+
+			return rest_ensure_response(
+				array(
+					'eligible' => false,
+					'messages' => array(
+						'title'   => isset( $results['title'] ) ? $results['title'] : esc_html__( 'Pas d’éligibilité apparente', 'advenir-eligibility-wizard' ),
+						'message' => isset( $results['message'] ) ? $results['message'] : esc_html__( 'Selon vos réponses, le projet ne semble pas éligible au programme Advenir.', 'advenir-eligibility-wizard' ),
+					),
+				)
+			);
+		}
+
+		$currency          = isset( $rules['_meta']['currency'] ) ? $rules['_meta']['currency'] : 'EUR';
+		$requested_points  = isset( $sanitized['points'] ) ? max( 0, (int) $sanitized['points'] ) : 0;
+		$max_points        = isset( $matched['max_points'] ) ? max( 0, (int) $matched['max_points'] ) : 0;
+		$amount_per_point  = isset( $matched['amount_per_point'] ) ? (float) $matched['amount_per_point'] : 0.0;
+		$eligible_points   = 0 === $max_points ? $requested_points : min( $requested_points, $max_points );
+		$total_estimate    = $eligible_points * $amount_per_point;
+		$eligible_messages = isset( $rules['results']['eligible'] ) ? $rules['results']['eligible'] : array();
+
+		$response = array(
+			'eligible' => true,
+			'scenario' => array(
+				'id'             => isset( $matched['id'] ) ? $matched['id'] : '',
+				'label'          => isset( $matched['label'] ) ? $matched['label'] : '',
+				'footnote'       => isset( $matched['footnote'] ) ? $matched['footnote'] : '',
+				'success_message'=> isset( $matched['success_message'] ) ? $matched['success_message'] : '',
+			),
+			'amounts'  => array(
+				'currency'        => $currency,
+				'amount_per_point'=> $amount_per_point,
+				'points_requested'=> $requested_points,
+				'points_eligible' => $eligible_points,
+				'total'           => $total_estimate,
+			),
+			'messages' => array(
+				'title'   => isset( $eligible_messages['title'] ) ? $eligible_messages['title'] : esc_html__( 'Félicitations !', 'advenir-eligibility-wizard' ),
+				'message' => isset( $eligible_messages['message'] ) ? $eligible_messages['message'] : esc_html__( 'Selon vos réponses, le projet semble éligible.', 'advenir-eligibility-wizard' ),
+			),
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Validate nonce for evaluate route.
+	 *
+	 * @param WP_REST_Request $request Request instance.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function validate_nonce( WP_REST_Request $request ) {
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			return new WP_Error( 'aew_invalid_nonce', esc_html__( 'Nonce invalide. Rechargez la page et réessayez.', 'advenir-eligibility-wizard' ), array( 'status' => 403 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Match answers to scenarios.
+	 *
+	 * @param array $scenarios List of scenarios.
+	 * @param array $answers   Sanitized answers.
+	 *
+	 * @return array|null
+	 */
+	private function match_scenario( $scenarios, $answers ) {
+		foreach ( $scenarios as $scenario ) {
+			if ( empty( $scenario['conditions'] ) || ! is_array( $scenario['conditions'] ) ) {
+				return $scenario;
+			}
+
+			$matches = true;
+
+			foreach ( $scenario['conditions'] as $question_id => $expected ) {
+				$question_id = sanitize_key( $question_id );
+
+				if ( ! array_key_exists( $question_id, $answers ) ) {
+					$matches = false;
+					break;
+				}
+
+				$answer_value = $answers[ $question_id ];
+
+				if ( is_array( $expected ) ) {
+					if ( $this->is_associative_array( $expected ) ) {
+						$min = isset( $expected['min'] ) ? (float) $expected['min'] : null;
+						$max = isset( $expected['max'] ) ? (float) $expected['max'] : null;
+
+						if ( null !== $min && $answer_value < $min ) {
+							$matches = false;
+							break;
+						}
+
+						if ( null !== $max && $answer_value > $max ) {
+							$matches = false;
+							break;
+						}
+					} else {
+						if ( is_array( $answer_value ) ) {
+							$intersect = array_intersect( $answer_value, $expected );
+
+							if ( empty( $intersect ) ) {
+								$matches = false;
+								break;
+							}
+						} elseif ( ! in_array( $answer_value, $expected, true ) ) {
+							$matches = false;
+							break;
+						}
+					}
+				} else {
+					if ( $answer_value !== $expected ) {
+						$matches = false;
+						break;
+					}
+				}
+			}
+
+			if ( $matches ) {
+				return $scenario;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check if array is associative.
+	 *
+	 * @param array $array Array to test.
+	 *
+	 * @return bool
+	 */
+	private function is_associative_array( $array ) {
+		if ( array() === $array ) {
+			return false;
+		}
+
+		return array_keys( $array ) !== range( 0, count( $array ) - 1 );
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,50 @@
+=== Advenir Eligibility Wizard ===
+Contributors: calcul-advenir
+Tags: advenir, electric vehicles, subsidy, wizard, questionnaire
+Requires at least: 6.4
+Tested up to: 6.4
+Requires PHP: 8.0
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A progressive questionnaire to help French site owners estimer l'éligibilité à l'aide Advenir et calculer les montants indicatifs.
+
+== Description ==
+Advenir Eligibility Wizard propose un parcours guidé en plusieurs étapes :
+
+* Les questions sont chargées depuis une configuration JSON administrable.
+* Les réponses sont évaluées via une API REST sécurisée pour déterminer l'éligibilité probable et estimer les montants par point de charge et le total.
+* Les scénarios, les textes de résultat et les barèmes peuvent être adaptés par l'administrateur du site sans modifier le code.
+
+Le plugin n'enregistre aucune donnée personnelle. Les réponses sont traitées uniquement côté navigateur et envoyées temporairement à l'API pour l'évaluation.
+
+== Installation ==
+1. Téléversez le dossier `advenir-eligibility-wizard` dans `/wp-content/plugins/` ou installez le ZIP depuis l'interface d'administration.
+2. Activez l'extension via le menu Extensions de WordPress.
+3. Rendez-vous dans **Advenir Wizard** dans le menu d'administration pour vérifier ou ajuster la configuration JSON.
+4. Ajoutez le shortcode `[advenir_wizard]` dans un article ou une page pour afficher l'assistant.
+
+== JSON de configuration ==
+Dans la page d'administration, une zone de texte permet de modifier la configuration :
+
+* `questions` décrit chaque étape (type `single` ou `number`).
+* `scenarios` définit les conditions d'éligibilité et les montants (plafond de points, montant par point, messages personnalisés).
+* `results` fournit les textes par défaut pour les cas éligibles ou non.
+
+Le plugin embarque un exemple qu'il convient d'adapter aux barèmes officiels. En cas de JSON invalide, l'ancienne configuration est conservée et un message d'erreur est affiché.
+
+== Shortcode ==
+`[advenir_wizard]` rend le formulaire complet et charge automatiquement les scripts nécessaires.
+
+== Sécurité et confidentialité ==
+* Les requêtes REST nécessitent un nonce WordPress (`wp_rest`).
+* Les capacités d'administration sont limitées aux utilisateurs pouvant gérer les options.
+* Aucune donnée personnelle n'est stockée ; les réponses ne servent qu'à la requête en cours.
+
+== Générer un fichier POT ==
+Pour extraire les chaînes de traduction, vous pouvez utiliser `wp i18n make-pot` ou tout outil équivalent pointant vers le dossier du plugin.
+
+== Changelog ==
+= 1.0.0 =
+* Première version publique.


### PR DESCRIPTION
## Summary
- scaffold the Advenir Eligibility Wizard plugin bootstrap and load the admin, REST, and front-end services
- implement an admin settings page with JSON configuration defaults, validation, and helper messaging for maintaining Advenir rules
- provide REST endpoints (`GET /aew/v1/config`, `POST /aew/v1/evaluate`) plus a localized shortcode that renders the multi-step wizard UI with vanilla JS and dedicated styles
- document installation, configuration, and shortcode usage in `readme.txt`

## Testing
- php -l advenir-eligibility-wizard.php
- php -l includes/class-aew-admin.php
- php -l includes/class-aew-frontend.php
- php -l includes/class-aew-rest.php

------
https://chatgpt.com/codex/tasks/task_e_68d68aa6eda08332bfae3382ddffbe6c